### PR TITLE
Add reserved dragons to my profile page

### DIFF
--- a/src/Components/dragons/dragons.js
+++ b/src/Components/dragons/dragons.js
@@ -1,10 +1,10 @@
 import React, { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux/es/exports';
-import { fetchDragons } from '../../redux/dragons/dragons.redux';
+import { fetchDragons, selectAllDragons } from '../../redux/dragons/dragons.redux';
 import BabyDragon from './BabyDragon';
 
 const Dragon = () => {
-  const dragons = useSelector((state) => state.dragons);
+  const dragons = useSelector(selectAllDragons);
   const dispatch = useDispatch();
   useEffect(() => {
     if (!dragons.length) {

--- a/src/Components/my_profile/my_profile.js
+++ b/src/Components/my_profile/my_profile.js
@@ -2,10 +2,12 @@ import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import './my_profile.css';
 import { PopulateMissionProfile } from '../../redux/missions/missions';
+import { selectAllDragons } from '../../redux/dragons/dragons.redux';
 
 const Myprofile = () => {
   const dispatch = useDispatch();
   const missions = useSelector((state) => state.missionReducer);
+  const dragons = useSelector(selectAllDragons);
 
   useEffect(() => {
     dispatch(PopulateMissionProfile());
@@ -30,6 +32,15 @@ const Myprofile = () => {
       </section>
       <section className="my-comp">
         <h2>My Dragons</h2>
+        <ul className="reservedCont">
+          { dragons.map((dragon) => (dragon.reserved === true ? (
+            <li className="reservedItem" key={dragon.id}>
+              {' '}
+              {dragon.name}
+              {' '}
+            </li>
+          ) : null))}
+        </ul>
       </section>
     </div>
   );

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,6 @@ import './index.css';
 import App from './App';
 import store from './redux/configureStore';
 import reportWebVitals from './reportWebVitals';
-// import store from './Components/rockets/configStore';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(

--- a/src/redux/dragons/dragons.redux.js
+++ b/src/redux/dragons/dragons.redux.js
@@ -74,4 +74,6 @@ export const cancelReservation = (id) => ({
   payload: id,
 });
 
+export const selectAllDragons = (state) => state.dragons;
+
 export default dragonsReducer;


### PR DESCRIPTION
The changes implemented in this branch:
- Count and display the reserved dragons on the My Profile page.
- Remove the canceled reservations from the My Profile page.